### PR TITLE
[Fix] ⚙️ AutorService GetByNome não retornava o nome completo do autor.

### DIFF
--- a/Codigo2022/Biblioteca2022/Service/AutorService.cs
+++ b/Codigo2022/Biblioteca2022/Service/AutorService.cs
@@ -84,7 +84,7 @@ namespace Service
 						select new AutorDTO
 						{
 							IdAutor = autor.IdAutor,
-							Nome = nome
+							Nome = autor.Nome
 						};
 			return query;
 		}


### PR DESCRIPTION
Problema: O método GetByNome do AutorService não estava retornando o nome completo.

Solução: Corrigido ao referenciar o nome do objeto encontrado na consulta pelo nome, ao invés de retornar o nome que veio como parâmetro.